### PR TITLE
Default header for guitar strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@j6k4m8/catl-parser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@j6k4m8/catl-parser",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsup": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@j6k4m8/catl-parser",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Parser for CATL (Chord and Tab Language)",
   "license": "Apache-2.0",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { lex } from "./lexer";
 import { parse } from "./parser";
 import { FileAST } from "./ast";
+export * from "./ast";
 
 export function parseCATL(input: string): FileAST {
     const { tokens, diagnostics } = lex(input);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,6 +8,7 @@ import { Token, TokenKind } from "./lexer";
 export function parse(tokens: Token[], lexerDiagnostics: Diagnostic[] = []): FileAST {
     const diagnostics: Diagnostic[] = [...lexerDiagnostics];
     let i = 0;
+    const DEFAULT_HEADER_STRING_IDS = ["e", "B", "G", "D", "A", "E"];
 
     const peek = (k = 0) => tokens[i + k] ?? tokens[tokens.length - 1];
     const at = (kind: TokenKind, k = 0) => peek(k).kind === kind;
@@ -269,6 +270,21 @@ export function parse(tokens: Token[], lexerDiagnostics: Diagnostic[] = []): Fil
         const stmt = parseStatementLine();
         if (at("Newline")) next();
         lines.push(stmt);
+    }
+
+    const hasHeaderLine = lines.some((line) => line.kind === "HeaderLine");
+    if (!hasHeaderLine) {
+        const start = tokens[0]?.span.start ?? { offset: 0, line: 1, col: 1 };
+        const defaultHeader: HeaderNode = {
+            kind: "Header",
+            stringIds: DEFAULT_HEADER_STRING_IDS,
+            span: { start, end: start }
+        };
+        lines.unshift({
+            kind: "HeaderLine",
+            header: defaultHeader,
+            span: { start, end: start }
+        });
     }
 
     return { lines, diagnostics };

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -2,13 +2,24 @@ import { describe, it, expect } from "vitest";
 import { parseCATL } from "../src/index";
 
 describe("CATL parser", () => {
+    it("defaults to {eBGDAE} header when no header is provided", () => {
+        const src = `0A:"When" 0D 5e:"you"\n`;
+        const ast = parseCATL(src);
+
+        expect(ast.diagnostics.filter(d => d.severity === "error")).toHaveLength(0);
+        expect(ast.lines[0].kind).toBe("HeaderLine");
+        // @ts-expect-error narrow
+        expect(ast.lines[0].header.stringIds.join("")).toBe("eBGDAE");
+        expect(ast.lines[1].kind).toBe("StatementLine");
+    });
+
     it("parses chord specs with prefix name + suffix annotation", () => {
         const src = `"Gmin7":3x332x:"Nice chord!"\n`;
         const ast = parseCATL(src);
 
         expect(ast.diagnostics.filter(d => d.severity === "error")).toHaveLength(0);
 
-        const line = ast.lines[0];
+        const line = ast.lines[1];
         expect(line.kind).toBe("StatementLine");
 
         // @ts-expect-error narrow
@@ -76,7 +87,7 @@ describe("CATL parser", () => {
 
         expect(ast.diagnostics.filter(d => d.severity === "error")).toHaveLength(0);
 
-        const stmt = ast.lines[0];
+        const stmt = ast.lines[1];
         expect(stmt.kind).toBe("StatementLine");
         // @ts-expect-error narrow
         const kinds = stmt.elements.map(e => e.kind);


### PR DESCRIPTION
- [ ] default header for guitar fixes #1 
- [ ] re-export AST types from the entry point so consumers can access the lexer/parser output structures
- [ ]  bump package and lockfile version to 0.1.2 bc of new export